### PR TITLE
add Containing Contravariant instance

### DIFF
--- a/scalatest-fs2/src/main/scala/com/dwolla/testutils/scalatest/ScalaTestCatsInstances.scala
+++ b/scalatest-fs2/src/main/scala/com/dwolla/testutils/scalatest/ScalaTestCatsInstances.scala
@@ -1,0 +1,20 @@
+package com.dwolla.testutils.scalatest
+
+import cats._
+import cats.implicits._
+import fs2._
+import org.scalatest.enablers.Containing
+
+trait ScalaTestCatsInstances {
+  implicit def ContainingContravariant: Contravariant[Containing] = new Contravariant[Containing] {
+    override def contramap[A, B](fa: Containing[A])(f: B ⇒ A): Containing[B] = new Containing[B] {
+      override def contains(container: B, element: Any): Boolean = fa.contains(f(container), element)
+
+      override def containsOneOf(container: B, elements: Seq[Any]): Boolean = fa.containsOneOf(f(container), elements)
+
+      override def containsNoneOf(container: B, elements: Seq[Any]): Boolean = fa.containsNoneOf(f(container), elements)
+    }
+  }
+
+  implicit def fs2ChunkContains[T](implicit listContains: Containing[List[T]]): Containing[Chunk[T]] = listContains.contramap(_.toList)
+}

--- a/scalatest-fs2/src/main/scala/com/dwolla/testutils/scalatest/package.scala
+++ b/scalatest-fs2/src/main/scala/com/dwolla/testutils/scalatest/package.scala
@@ -1,0 +1,3 @@
+package com.dwolla.testutils
+
+package object scalatest extends ScalaTestCatsInstances

--- a/scalatest-fs2/src/test/scala/com/dwolla/testutils/ContainsTest.scala
+++ b/scalatest-fs2/src/test/scala/com/dwolla/testutils/ContainsTest.scala
@@ -1,0 +1,25 @@
+package com.dwolla.testutils
+
+import com.dwolla.testutils.scalatest._
+import fs2._
+import org.scalatest._
+
+class ContainsTest extends FlatSpec with Matchers {
+
+  "Contains" should "support fs2.Chunk" in {
+    Chunk("hello", "goodbye") should contain("hello")
+  }
+
+  it should "support negation with fs2.Chunk too" in {
+    Chunk("hello", "world") should not(contain("goodbye"))
+  }
+
+  "containsOneOf" should "support fs2.Chunk" in {
+    Chunk(2, 3, 4) should contain oneOf(1, 2)
+  }
+
+  "containsNoneOf" should "support fs2.Chunk" in {
+    Chunk(0, 1, 2) should contain noneOf(3, 4, 5)
+  }
+
+}


### PR DESCRIPTION
 and use it for `Containing[Chunk[T]]`

I'm not sure if our library is the best place for this kind of thing or not. I asked in the cats project gitter channel if anyone could suggest a community library that would be interested in these instances, so I may withdraw this PR if there's a better home for them.