### PR TITLE
Add IOErrorSpec helper

### DIFF
--- a/scalatest-fs2/README.md
+++ b/scalatest-fs2/README.md
@@ -65,3 +65,18 @@ Note that the syntax above requires the [better-monadic-for](https://github.com/
 ## Concurrency Helpers
 
 `Pledge[F, A]` can be used as a pure-functional form of `scala.concurrent.Promise[A]`, and `completeThePledgeOnCancel` is a helper to construct a `Fiber[F, Unit]`, the cancelation of which will complete the given `Pledge[F, ?]`. This can be used to assert that a fiber obtained the normal way would be canceled if a timeout occurs, for example, without having to actually wait for a timeout.
+
+## `IOErrorSpec` example
+```scala
+class IOErrorSpecExample extends IOSpec with org.scalatest.Matchers with IOErrorSpec {
+
+  "MyGreatCode" should "throw an Exception" inIO {
+    shouldThrowAn[Exception] {
+        IO.raiseError(new Exception)
+    }
+  }
+
+}
+```
+
+This helper trait will ensure an exception of the specified type is thrown inside the `IO`.

--- a/scalatest-fs2/src/main/scala/com/dwolla/testutils/IOErrorSpec.scala
+++ b/scalatest-fs2/src/main/scala/com/dwolla/testutils/IOErrorSpec.scala
@@ -1,0 +1,33 @@
+package com.dwolla.testutils
+
+import cats.effect.IO
+import org.scalactic.source.Position
+import org.scalatest.{Assertion, Assertions, Succeeded}
+
+import scala.reflect.ClassTag
+
+trait IOErrorSpec extends Assertions {
+
+  def shouldThrowA[T <: AnyRef](
+    anIO: IO[_]
+  )(implicit classTag: ClassTag[T], pos: Position): IO[Assertion] =
+    anIO.attempt
+      .map {
+        case Left(_: T)    => Succeeded
+        case Left(error)   =>
+          fail(
+            s"Expected an exception of type ${classTag.runtimeClass.getName}, but $error was thrown"
+          )(pos)
+        case Right(result) =>
+          fail(
+            s"Expected an exception of type ${classTag.runtimeClass.getName}, but the IO succeeded with result $result"
+          )(
+            pos
+          )
+      }
+
+  def shouldThrowAn[T <: AnyRef](
+    anIO: IO[_]
+  )(implicit classTag: ClassTag[T], pos: Position): IO[Assertion] =
+    shouldThrowA[T](anIO)
+}

--- a/scalatest-fs2/src/test/scala/com/dwolla/testutils/IOErrorSpecTest.scala
+++ b/scalatest-fs2/src/test/scala/com/dwolla/testutils/IOErrorSpecTest.scala
@@ -1,0 +1,34 @@
+package com.dwolla.testutils
+
+import cats.effect.IO
+import org.scalatest.EitherValues
+import org.scalatest.exceptions.TestFailedException
+import org.scalatest.matchers.should.Matchers
+
+class IOErrorSpecTest extends IOSpec with Matchers with EitherValues with IOErrorSpec {
+  behavior of "IOErrorSpec.shouldThrowA"
+
+  it should "pass successfully when an error of the correct type is thrown" inIO {
+    shouldThrowA[CatchMe] {
+      IO.raiseError(new CatchMe)
+    }
+  }
+
+  it should "fail when an error of a different type is thrown" inIO {
+    for {
+      result <- shouldThrowA[CatchMe] {
+                  IO.raiseError(new Exception)
+                }.attempt
+    } yield result.left.value shouldBe a[TestFailedException]
+  }
+
+  it should "fail when no error is thrown" inIO {
+    for {
+      result <- shouldThrowA[CatchMe] {
+                  IO.pure(1)
+                }.attempt
+    } yield result.left.value shouldBe a[TestFailedException]
+  }
+
+  private class CatchMe extends Exception
+}


### PR DESCRIPTION
* This trait facilitates checking if the `IO` under test raises an expected error
* Test included
* README updated